### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build-test-and-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mikedevnull/majestic-cards/security/code-scanning/1](https://github.com/mikedevnull/majestic-cards/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/testing.yaml` at the workflow root (between `on:` and `jobs:` is a clear location). For this pipeline, the minimal safe baseline is:

- `contents: read` (required for checkout and normal repository read access)

This preserves existing functionality while constraining `GITHUB_TOKEN` scopes. No imports, methods, or additional definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
